### PR TITLE
Update github ci output variable in new way:

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -13,9 +13,9 @@ jobs:
         run: |
           git fetch origin main &&
           MAIN=`git rev-parse origin/main` &&
-          echo "::set-output name=head_of_main::$MAIN" &&
+          echo "head_of_main=$MAIN" >> $GITHUB_OUTPUT &&
           CURRENT=`git rev-list -n 1 ${{ github.ref }} || echo "NOT_MAIN"` &&
-          echo "::set-output name=current_job_ref::$CURRENT"
+          echo "current_job_ref=$CURRENT" >> $GITHUB_OUTPUT
       - name: Set up JDK
         if: steps.check_head_of_main.outputs.head_of_main == steps.check_head_of_main.outputs.current_job_ref
         uses: actions/setup-java@v4


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/